### PR TITLE
Refactor main page layout and JS modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,24 +20,24 @@
     </script>
 </head>
 <body class="font-sans bg-gray-50 text-gray-800">
-    <header class="bg-white shadow">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
+    <header class="sticky top-0 z-50 bg-white shadow-md">
+        <div class="max-w-7xl mx-auto px-4 flex items-center justify-between h-16">
             <a href="#" class="text-lg font-semibold">Tennis Tracker</a>
             <nav class="hidden md:flex space-x-6">
                 <a href="#todo" class="text-gray-600 hover:text-gray-900">Tâches</a>
                 <a href="#players" class="text-gray-600 hover:text-gray-900">Joueurs</a>
-                <a href="#training" class="text-gray-600 hover:text-gray-900">Entraînements</a>
-                <a href="#stats" class="text-gray-600 hover:text-gray-900">Stats</a>
+                <a href="#history" class="text-gray-600 hover:text-gray-900">Entraînements</a>
+                <a href="#progress" class="text-gray-600 hover:text-gray-900">Progression</a>
             </nav>
             <button id="menu-btn" class="md:hidden p-2 rounded hover:bg-gray-100" aria-label="Menu">
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"></path></svg>
             </button>
         </div>
-        <div id="mobile-menu" class="md:hidden hidden px-4 pb-4">
+        <div id="mobile-menu" class="md:hidden hidden px-4 pb-4 space-y-1">
             <a href="#todo" class="block py-1 text-gray-600 hover:text-gray-900">Tâches</a>
             <a href="#players" class="block py-1 text-gray-600 hover:text-gray-900">Joueurs</a>
-            <a href="#training" class="block py-1 text-gray-600 hover:text-gray-900">Entraînements</a>
-            <a href="#stats" class="block py-1 text-gray-600 hover:text-gray-900">Stats</a>
+            <a href="#history" class="block py-1 text-gray-600 hover:text-gray-900">Entraînements</a>
+            <a href="#progress" class="block py-1 text-gray-600 hover:text-gray-900">Progression</a>
         </div>
     </header>
 
@@ -52,10 +52,10 @@
         </div>
     </section>
 
-    <main class="max-w-3xl mx-auto px-4 py-12">
-        <section class="mb-12" id="todo">
-            <h2 class="text-2xl font-semibold mb-4">To-do List</h2>
-            <form id="todo-form" class="grid grid-cols-1 md:grid-cols-2 gap-2 mb-4">
+    <main class="max-w-3xl mx-auto px-4 py-12 space-y-16">
+        <section id="todo" class="space-y-4">
+            <h2 class="text-2xl font-semibold">To-do List</h2>
+            <form id="todo-form" class="grid grid-cols-1 md:grid-cols-2 gap-2">
                 <input id="todo-title" type="text" placeholder="Titre" class="border rounded-md px-3 py-2" />
                 <input id="todo-category" type="text" placeholder="Catégorie" class="border rounded-md px-3 py-2" />
                 <select id="todo-priority" class="border rounded-md px-3 py-2">
@@ -65,14 +65,14 @@
                     <option value="Basse">Basse</option>
                 </select>
                 <textarea id="todo-desc" placeholder="Description" class="border rounded-md px-3 py-2 md:col-span-2"></textarea>
-                <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 md:col-span-2">Ajouter</button>
+                <button id="todo-submit" type="submit" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 md:col-span-2">Ajouter</button>
             </form>
             <ul id="todo-list" class="space-y-2"></ul>
         </section>
 
-        <section class="mb-12" id="players">
-            <h2 class="text-2xl font-semibold mb-4">Base de données joueurs</h2>
-            <form id="player-form" class="grid grid-cols-1 gap-3 mb-4">
+        <section id="players" class="space-y-4">
+            <h2 class="text-2xl font-semibold">Base de données joueurs</h2>
+            <form id="player-form" class="grid grid-cols-1 gap-3">
                 <input id="player-name" type="text" placeholder="Nom" class="border rounded-md px-3 py-2" />
                 <input id="player-rank" type="text" placeholder="Classement" class="border rounded-md px-3 py-2" />
                 <textarea id="player-notes" placeholder="Points forts, style de jeu" class="border rounded-md px-3 py-2"></textarea>
@@ -93,9 +93,9 @@
             </div>
         </section>
 
-        <section class="mb-12" id="training">
-            <h2 class="text-2xl font-semibold mb-4">Journal d'entraînement</h2>
-            <form id="training-form" class="grid grid-cols-1 gap-3 mb-4">
+        <section id="history" class="space-y-4">
+            <h2 class="text-2xl font-semibold">Journal d'entraînement</h2>
+            <form id="training-form" class="grid grid-cols-1 gap-3">
                 <input id="training-date" type="date" class="border rounded-md px-3 py-2" />
                 <input id="training-duration" type="text" placeholder="Durée" class="border rounded-md px-3 py-2" />
                 <select id="training-type" class="border rounded-md px-3 py-2">
@@ -106,6 +106,19 @@
                 <textarea id="training-notes" placeholder="Notes" class="border rounded-md px-3 py-2"></textarea>
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 w-max">Ajouter</button>
             </form>
+            <div class="flex flex-col md:flex-row gap-4">
+                <select id="filter-range" class="border rounded-md px-3 py-2 w-full md:w-auto">
+                    <option value="">Toutes les dates</option>
+                    <option value="7">7 derniers jours</option>
+                    <option value="30">30 derniers jours</option>
+                </select>
+                <select id="filter-type" class="border rounded-md px-3 py-2 w-full md:w-auto">
+                    <option value="all">Tous les types</option>
+                    <option value="Technique">Technique</option>
+                    <option value="Physique">Physique</option>
+                    <option value="Match">Match</option>
+                </select>
+            </div>
             <div class="overflow-x-auto">
                 <table id="training-table" class="min-w-full divide-y divide-gray-200 text-sm">
                     <thead class="bg-gray-50">
@@ -122,10 +135,9 @@
             </div>
         </section>
 
-        <section id="stats">
-            <h2 class="text-2xl font-semibold mb-4">Suivi visuel</h2>
-            <canvas id="sessions-chart" height="200" class="mb-6"></canvas>
-            <canvas id="types-chart" height="200"></canvas>
+        <section id="progress" class="space-y-4">
+            <h2 class="text-2xl font-semibold">Progression</h2>
+            <canvas id="progressChart" height="200"></canvas>
         </section>
     </main>
 


### PR DESCRIPTION
## Summary
- rebuild index layout with sticky header, sections and progress chart
- enhance to-do list with edit mode
- add filters to training history
- update chart logic to use filtered data

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_6842dd97e7bc83339aa01091374ee11e