### PR TITLE
Améliorer la navigation et séparer les fonctionnalités

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const todoList = document.getElementById('todo-list');
     const todoSubmit = document.getElementById('todo-submit');
     const taskAlert = document.getElementById('task-alert');
+    if (todoForm) {
 
     function showAlert(message, color) {
         taskAlert.textContent = message;
@@ -145,10 +146,13 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     renderTasks();
+    }
 
     // Player database
     const playerForm = document.getElementById('player-form');
     const playersTableBody = document.querySelector('#players-table tbody');
+
+    if (playerForm) {
 
     let players = JSON.parse(localStorage.getItem('players') || '[]');
     let editIndex = null;
@@ -203,12 +207,14 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     renderPlayers();
+    }
 
     // Training journal
     const trainingForm = document.getElementById('training-form');
     const trainingTableBody = document.querySelector('#training-table tbody');
     const filterRange = document.getElementById('filter-range');
     const filterType = document.getElementById('filter-type');
+    const progressEl = document.getElementById('progressChart');
 
     let sessions = JSON.parse(localStorage.getItem('sessions') || '[]');
 
@@ -218,18 +224,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function getFilteredSessions() {
         let data = [...sessions];
-        if (filterRange.value) {
+        if (filterRange && filterRange.value) {
             const days = parseInt(filterRange.value, 10);
             const limit = Date.now() - days * 86400000;
             data = data.filter(s => new Date(s.date).getTime() >= limit);
         }
-        if (filterType.value !== 'all') {
+        if (filterType && filterType.value !== 'all') {
             data = data.filter(s => s.type === filterType.value);
         }
         return data;
     }
 
     function renderSessions() {
+        if (!trainingTableBody) return;
         trainingTableBody.innerHTML = '';
         getFilteredSessions().forEach((s, idx) => {
             const row = document.createElement('tr');
@@ -252,7 +259,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    trainingForm.addEventListener('submit', e => {
+    if (trainingForm) trainingForm.addEventListener('submit', e => {
         e.preventDefault();
         const date = document.getElementById('training-date').value;
         const duration = document.getElementById('training-duration').value.trim();
@@ -266,22 +273,23 @@ document.addEventListener('DOMContentLoaded', () => {
         updateCharts();
     });
 
-    filterRange.addEventListener('change', () => {
+    if (filterRange) filterRange.addEventListener('change', () => {
         renderSessions();
         updateCharts();
     });
-    filterType.addEventListener('change', () => {
+    if (filterType) filterType.addEventListener('change', () => {
         renderSessions();
         updateCharts();
     });
 
-    renderSessions();
+    if (trainingTableBody) renderSessions();
 
     // Charts
-    const progressCtx = document.getElementById('progressChart').getContext('2d');
+    const progressCtx = progressEl ? progressEl.getContext('2d') : null;
     let progressChart = null;
 
     function updateCharts() {
+        if (!progressCtx) return;
         const sessionsPerMonth = {};
         getFilteredSessions().forEach(s => {
             const month = s.date.substring(0,7); // YYYY-MM
@@ -301,7 +309,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    updateCharts();
+    if (progressCtx) updateCharts();
 
     // Schedule calendar
     const calendarEl = document.getElementById('calendar');

--- a/entrainements.html
+++ b/entrainements.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Entraînements - Tennis Tracker</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui']
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="font-sans bg-gray-50 text-gray-800 flex">
+  <nav class="w-48 h-screen fixed left-0 top-0 bg-white shadow-md p-4 space-y-2">
+    <a href="index.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Accueil</a>
+    <a href="tasks.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Tâches</a>
+    <a href="joueurs.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Joueurs</a>
+    <a href="entrainements.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Entraînements</a>
+    <a href="planning.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Planning</a>
+    <a href="progression.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Progression</a>
+  </nav>
+  <main class="flex-1 ml-48 p-8 space-y-4">
+    <h1 class="text-2xl font-semibold">Journal d'entraînement</h1>
+    <form id="training-form" class="grid grid-cols-1 gap-3">
+      <input id="training-date" type="date" class="border rounded-md px-3 py-2" />
+      <input id="training-duration" type="text" placeholder="Durée" class="border rounded-md px-3 py-2" />
+      <select id="training-type" class="border rounded-md px-3 py-2">
+        <option value="Technique">Technique</option>
+        <option value="Physique">Physique</option>
+        <option value="Match">Match</option>
+      </select>
+      <textarea id="training-notes" placeholder="Notes" class="border rounded-md px-3 py-2"></textarea>
+      <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 w-max">Ajouter</button>
+    </form>
+    <div class="flex flex-col md:flex-row gap-4">
+      <select id="filter-range" class="border rounded-md px-3 py-2 w-full md:w-auto">
+        <option value="">Toutes les dates</option>
+        <option value="7">7 derniers jours</option>
+        <option value="30">30 derniers jours</option>
+      </select>
+      <select id="filter-type" class="border rounded-md px-3 py-2 w-full md:w-auto">
+        <option value="all">Tous les types</option>
+        <option value="Technique">Technique</option>
+        <option value="Physique">Physique</option>
+        <option value="Match">Match</option>
+      </select>
+    </div>
+    <div class="overflow-x-auto">
+      <table id="training-table" class="min-w-full divide-y divide-gray-200 text-sm">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-3 py-2 text-left font-semibold text-gray-700">Date</th>
+            <th class="px-3 py-2 text-left font-semibold text-gray-700">Durée</th>
+            <th class="px-3 py-2 text-left font-semibold text-gray-700">Type</th>
+            <th class="px-3 py-2 text-left font-semibold text-gray-700">Notes</th>
+            <th class="px-3 py-2"></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200"></tbody>
+      </table>
+    </div>
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,172 +1,57 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Tennis Tracker</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css" rel="stylesheet">
-    <script>
-      tailwind.config = {
-        theme: {
-          extend: {
-            fontFamily: {
-              sans: ['Inter', 'ui-sans-serif', 'system-ui']
-            }
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tennis Tracker</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui']
           }
         }
       }
-    </script>
-    <style>
-      html { scroll-behavior: smooth; }
-      #calendar { max-width: 100%; margin: 0 auto; }
-    </style>
+    }
+  </script>
 </head>
-<body class="font-sans bg-gray-50 text-gray-800">
-    <header class="sticky top-0 z-50 bg-white shadow-md">
-        <div class="max-w-7xl mx-auto px-4 flex items-center justify-between h-16">
-            <a href="#" class="text-lg font-semibold">Tennis Tracker</a>
-            <nav class="hidden md:flex space-x-6">
-                <a href="#todo" class="text-gray-600 hover:text-gray-900">Tâches</a>
-                <a href="#players" class="text-gray-600 hover:text-gray-900">Joueurs</a>
-                <a href="#history" class="text-gray-600 hover:text-gray-900">Entraînements</a>
-                <a href="#schedule" class="text-gray-600 hover:text-gray-900">Planning</a>
-                <a href="#progress" class="text-gray-600 hover:text-gray-900">Progression</a>
-            </nav>
-            <button id="menu-btn" class="md:hidden p-2 rounded hover:bg-gray-100" aria-label="Menu">
-                <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"></path></svg>
-            </button>
-        </div>
-        <div id="mobile-menu" class="md:hidden hidden px-4 pb-4 space-y-1">
-            <a href="#todo" class="block py-1 text-gray-600 hover:text-gray-900">Tâches</a>
-            <a href="#players" class="block py-1 text-gray-600 hover:text-gray-900">Joueurs</a>
-            <a href="#history" class="block py-1 text-gray-600 hover:text-gray-900">Entraînements</a>
-            <a href="#schedule" class="block py-1 text-gray-600 hover:text-gray-900">Planning</a>
-            <a href="#progress" class="block py-1 text-gray-600 hover:text-gray-900">Progression</a>
-        </div>
-    </header>
-
-    <section id="hero" class="bg-white">
-        <div class="max-w-7xl mx-auto px-4 py-20 grid md:grid-cols-2 gap-8 items-center">
-            <div>
-                <h1 class="text-4xl md:text-5xl font-semibold mb-4">Gérez vos entraînements de tennis</h1>
-                <p class="text-lg text-gray-600 mb-6">Organisez vos tâches, suivez vos adversaires et visualisez vos progrès.</p>
-                <a href="#todo" class="inline-block bg-blue-600 text-white px-6 py-3 rounded-md shadow hover:bg-blue-700">Commencer</a>
-            </div>
-            <img src="https://images.unsplash.com/photo-1521412644187-c49fa049e84d?auto=format&fit=crop&w=800&q=60" alt="Tennis" class="w-full rounded-lg shadow-md hidden md:block">
-        </div>
-    </section>
-
-    <main class="max-w-3xl mx-auto px-4 py-12 space-y-16">
-        <section id="todo" class="space-y-4">
-            <h2 class="text-2xl font-semibold">To-do List</h2>
-            <form id="todo-form" class="grid grid-cols-1 md:grid-cols-2 gap-2">
-                <input id="todo-title" type="text" placeholder="Titre" class="border rounded-md px-3 py-2" />
-                <input id="todo-category" type="text" placeholder="Catégorie" class="border rounded-md px-3 py-2" />
-                <select id="todo-priority" class="border rounded-md px-3 py-2">
-                    <option value="">Priorité</option>
-                    <option value="Haute">Haute</option>
-                    <option value="Moyenne">Moyenne</option>
-                    <option value="Basse">Basse</option>
-                </select>
-                <textarea id="todo-desc" placeholder="Description" class="border rounded-md px-3 py-2 md:col-span-2"></textarea>
-                <button id="todo-submit" type="submit" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 md:col-span-2">Ajouter</button>
-            </form>
-            <ul id="todo-list" class="space-y-2"></ul>
-            <div id="task-alert" class="fixed top-4 right-4 bg-green-500 text-white px-3 py-2 rounded shadow opacity-0 transition-opacity"></div>
-        </section>
-
-        <section id="players" class="space-y-4">
-            <h2 class="text-2xl font-semibold">Base de données joueurs</h2>
-            <form id="player-form" class="grid grid-cols-1 gap-3">
-                <input id="player-name" type="text" placeholder="Nom" class="border rounded-md px-3 py-2" />
-                <input id="player-rank" type="text" placeholder="Classement" class="border rounded-md px-3 py-2" />
-                <textarea id="player-notes" placeholder="Points forts, style de jeu" class="border rounded-md px-3 py-2"></textarea>
-                <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 w-max">Enregistrer</button>
-            </form>
-            <div class="overflow-x-auto">
-                <table id="players-table" class="min-w-full divide-y divide-gray-200 text-sm">
-                    <thead class="bg-gray-50">
-                        <tr>
-                            <th class="px-3 py-2 text-left font-semibold text-gray-700">Nom</th>
-                            <th class="px-3 py-2 text-left font-semibold text-gray-700">Classement</th>
-                            <th class="px-3 py-2 text-left font-semibold text-gray-700">Notes</th>
-                            <th class="px-3 py-2"></th>
-                        </tr>
-                    </thead>
-                    <tbody class="divide-y divide-gray-200"></tbody>
-                </table>
-            </div>
-        </section>
-
-        <section id="history" class="space-y-4">
-            <h2 class="text-2xl font-semibold">Journal d'entraînement</h2>
-            <form id="training-form" class="grid grid-cols-1 gap-3">
-                <input id="training-date" type="date" class="border rounded-md px-3 py-2" />
-                <input id="training-duration" type="text" placeholder="Durée" class="border rounded-md px-3 py-2" />
-                <select id="training-type" class="border rounded-md px-3 py-2">
-                    <option value="Technique">Technique</option>
-                    <option value="Physique">Physique</option>
-                    <option value="Match">Match</option>
-                </select>
-                <textarea id="training-notes" placeholder="Notes" class="border rounded-md px-3 py-2"></textarea>
-                <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 w-max">Ajouter</button>
-            </form>
-            <div class="flex flex-col md:flex-row gap-4">
-                <select id="filter-range" class="border rounded-md px-3 py-2 w-full md:w-auto">
-                    <option value="">Toutes les dates</option>
-                    <option value="7">7 derniers jours</option>
-                    <option value="30">30 derniers jours</option>
-                </select>
-                <select id="filter-type" class="border rounded-md px-3 py-2 w-full md:w-auto">
-                    <option value="all">Tous les types</option>
-                    <option value="Technique">Technique</option>
-                    <option value="Physique">Physique</option>
-                    <option value="Match">Match</option>
-                </select>
-            </div>
-            <div class="overflow-x-auto">
-                <table id="training-table" class="min-w-full divide-y divide-gray-200 text-sm">
-                    <thead class="bg-gray-50">
-                        <tr>
-                            <th class="px-3 py-2 text-left font-semibold text-gray-700">Date</th>
-                            <th class="px-3 py-2 text-left font-semibold text-gray-700">Durée</th>
-                            <th class="px-3 py-2 text-left font-semibold text-gray-700">Type</th>
-                            <th class="px-3 py-2 text-left font-semibold text-gray-700">Notes</th>
-                            <th class="px-3 py-2"></th>
-                        </tr>
-                    </thead>
-                    <tbody class="divide-y divide-gray-200"></tbody>
-                </table>
-            </div>
-        </section>
-
-        <section id="schedule" class="space-y-4">
-            <h2 class="text-2xl font-semibold">Planning</h2>
-            <div id="calendar"></div>
-        </section>
-
-        <section id="progress" class="space-y-4">
-            <h2 class="text-2xl font-semibold">Progression</h2>
-            <canvas id="progressChart" height="200"></canvas>
-        </section>
-    </main>
-
-    <footer class="bg-white border-t">
-        <div class="max-w-7xl mx-auto px-4 py-6 text-center text-sm text-gray-500">© 2025 Tennis Tracker</div>
-    </footer>
-
-    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
-    <script src="app.js"></script>
-    <script>
-        document.getElementById('menu-btn').addEventListener('click', () => {
-            const menu = document.getElementById('mobile-menu');
-            menu.classList.toggle('hidden');
-        });
-    </script>
+<body class="font-sans bg-gray-50 text-gray-800 flex">
+  <nav class="w-48 h-screen fixed left-0 top-0 bg-white shadow-md p-4 space-y-2">
+    <a href="index.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Accueil</a>
+    <a href="tasks.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Tâches</a>
+    <a href="joueurs.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Joueurs</a>
+    <a href="entrainements.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Entraînements</a>
+    <a href="planning.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Planning</a>
+    <a href="progression.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Progression</a>
+  </nav>
+  <main class="flex-1 ml-48 p-8">
+    <h1 class="text-3xl font-semibold mb-8">Tennis Tracker</h1>
+    <div class="grid md:grid-cols-2 gap-6">
+      <a href="tasks.html" class="block bg-white p-6 rounded-lg shadow hover:bg-blue-50 transition-colors">
+        <h2 class="text-xl font-semibold mb-2">Tâches</h2>
+        <p class="text-gray-600">Gérez vos tâches quotidiennes.</p>
+      </a>
+      <a href="joueurs.html" class="block bg-white p-6 rounded-lg shadow hover:bg-blue-50 transition-colors">
+        <h2 class="text-xl font-semibold mb-2">Joueurs</h2>
+        <p class="text-gray-600">Suivez vos adversaires et partenaires.</p>
+      </a>
+      <a href="entrainements.html" class="block bg-white p-6 rounded-lg shadow hover:bg-blue-50 transition-colors">
+        <h2 class="text-xl font-semibold mb-2">Entraînements</h2>
+        <p class="text-gray-600">Consignez vos séances.</p>
+      </a>
+      <a href="planning.html" class="block bg-white p-6 rounded-lg shadow hover:bg-blue-50 transition-colors">
+        <h2 class="text-xl font-semibold mb-2">Planning</h2>
+        <p class="text-gray-600">Planifiez vos prochaines séances.</p>
+      </a>
+      <a href="progression.html" class="block bg-white p-6 rounded-lg shadow hover:bg-blue-50 transition-colors md:col-span-2">
+        <h2 class="text-xl font-semibold mb-2">Progression</h2>
+        <p class="text-gray-600">Visualisez vos progrès au fil du temps.</p>
+      </a>
+    </div>
+  </main>
 </body>
 </html>

--- a/joueurs.html
+++ b/joueurs.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Joueurs - Tennis Tracker</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui']
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="font-sans bg-gray-50 text-gray-800 flex">
+  <nav class="w-48 h-screen fixed left-0 top-0 bg-white shadow-md p-4 space-y-2">
+    <a href="index.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Accueil</a>
+    <a href="tasks.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Tâches</a>
+    <a href="joueurs.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Joueurs</a>
+    <a href="entrainements.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Entraînements</a>
+    <a href="planning.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Planning</a>
+    <a href="progression.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Progression</a>
+  </nav>
+  <main class="flex-1 ml-48 p-8 space-y-4">
+    <h1 class="text-2xl font-semibold">Base de données joueurs</h1>
+    <form id="player-form" class="grid grid-cols-1 gap-3">
+      <input id="player-name" type="text" placeholder="Nom" class="border rounded-md px-3 py-2" />
+      <input id="player-rank" type="text" placeholder="Classement" class="border rounded-md px-3 py-2" />
+      <textarea id="player-notes" placeholder="Points forts, style de jeu" class="border rounded-md px-3 py-2"></textarea>
+      <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 w-max">Enregistrer</button>
+    </form>
+    <div class="overflow-x-auto">
+      <table id="players-table" class="min-w-full divide-y divide-gray-200 text-sm">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-3 py-2 text-left font-semibold text-gray-700">Nom</th>
+            <th class="px-3 py-2 text-left font-semibold text-gray-700">Classement</th>
+            <th class="px-3 py-2 text-left font-semibold text-gray-700">Notes</th>
+            <th class="px-3 py-2"></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200"></tbody>
+      </table>
+    </div>
+  </main>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/planning.html
+++ b/planning.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Planning - Tennis Tracker</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css" rel="stylesheet">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui']
+          }
+        }
+      }
+    }
+  </script>
+  <style>
+    #calendar { max-width: 100%; margin: 0 auto; }
+  </style>
+</head>
+<body class="font-sans bg-gray-50 text-gray-800 flex">
+  <nav class="w-48 h-screen fixed left-0 top-0 bg-white shadow-md p-4 space-y-2">
+    <a href="index.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Accueil</a>
+    <a href="tasks.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Tâches</a>
+    <a href="joueurs.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Joueurs</a>
+    <a href="entrainements.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Entraînements</a>
+    <a href="planning.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Planning</a>
+    <a href="progression.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Progression</a>
+  </nav>
+  <main class="flex-1 ml-48 p-8 space-y-4">
+    <h1 class="text-2xl font-semibold">Planning</h1>
+    <div id="calendar"></div>
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/progression.html
+++ b/progression.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Progression - Tennis Tracker</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui']
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="font-sans bg-gray-50 text-gray-800 flex">
+  <nav class="w-48 h-screen fixed left-0 top-0 bg-white shadow-md p-4 space-y-2">
+    <a href="index.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Accueil</a>
+    <a href="tasks.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Tâches</a>
+    <a href="joueurs.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Joueurs</a>
+    <a href="entrainements.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Entraînements</a>
+    <a href="planning.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Planning</a>
+    <a href="progression.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Progression</a>
+  </nav>
+  <main class="flex-1 ml-48 p-8 space-y-4">
+    <h1 class="text-2xl font-semibold">Progression</h1>
+    <canvas id="progressChart" height="200"></canvas>
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/tasks.html
+++ b/tasks.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tâches - Tennis Tracker</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui']
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="font-sans bg-gray-50 text-gray-800 flex">
+  <nav class="w-48 h-screen fixed left-0 top-0 bg-white shadow-md p-4 space-y-2">
+    <a href="index.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Accueil</a>
+    <a href="tasks.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Tâches</a>
+    <a href="joueurs.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Joueurs</a>
+    <a href="entrainements.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Entraînements</a>
+    <a href="planning.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Planning</a>
+    <a href="progression.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Progression</a>
+  </nav>
+  <main class="flex-1 ml-48 p-8 space-y-4">
+    <h1 class="text-2xl font-semibold">To-do List</h1>
+    <form id="todo-form" class="grid grid-cols-1 md:grid-cols-2 gap-2">
+      <input id="todo-title" type="text" placeholder="Titre" class="border rounded-md px-3 py-2" />
+      <input id="todo-category" type="text" placeholder="Catégorie" class="border rounded-md px-3 py-2" />
+      <select id="todo-priority" class="border rounded-md px-3 py-2">
+        <option value="">Priorité</option>
+        <option value="Haute">Haute</option>
+        <option value="Moyenne">Moyenne</option>
+        <option value="Basse">Basse</option>
+      </select>
+      <textarea id="todo-desc" placeholder="Description" class="border rounded-md px-3 py-2 md:col-span-2"></textarea>
+      <button id="todo-submit" type="submit" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 md:col-span-2">Ajouter</button>
+    </form>
+    <ul id="todo-list" class="space-y-2"></ul>
+    <div id="task-alert" class="fixed top-4 right-4 bg-green-500 text-white px-3 py-2 rounded shadow opacity-0 transition-opacity"></div>
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add sidebar navigation and grid home page
- create dedicated pages for tasks, players, trainings, planning and progression
- guard JS modules so pages work independently

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842f78c721c833391929aa88daf7a18