### PR TITLE
Add dashboard overview on home page

### DIFF
--- a/app.js
+++ b/app.js
@@ -352,4 +352,55 @@ document.addEventListener('DOMContentLoaded', () => {
 
         calendar.render();
     }
+
+    // Dashboard on index.html
+    const dashboard = document.getElementById('dashboard');
+    const weeklyList = document.getElementById('weekly-sessions');
+    if (dashboard) {
+        function renderDashboard() {
+            const tasksData = JSON.parse(localStorage.getItem('tasks') || '[]');
+            const sessionsData = JSON.parse(localStorage.getItem('sessions') || '[]');
+            const playersData = JSON.parse(localStorage.getItem('players') || '[]');
+
+            document.getElementById('metric-sessions').textContent = sessionsData.length;
+
+            const totalMinutes = sessionsData.reduce((sum, s) => {
+                const m = parseInt(s.duration, 10);
+                return sum + (isNaN(m) ? 0 : m);
+            }, 0);
+            document.getElementById('metric-time').textContent = totalMinutes + ' min';
+
+            const tasksInProgress = tasksData.filter(t => !t.done).length;
+            document.getElementById('metric-tasks').textContent = tasksInProgress;
+
+            document.getElementById('metric-players').textContent = playersData.length;
+
+            if (weeklyList) {
+                const weekAgo = Date.now() - 7 * 86400000;
+                const recent = sessionsData
+                    .filter(s => new Date(s.date).getTime() >= weekAgo)
+                    .sort((a, b) => new Date(a.date) - new Date(b.date));
+                weeklyList.innerHTML = '';
+                recent.forEach(s => {
+                    const li = document.createElement('li');
+                    li.className = 'flex items-center gap-2';
+                    const type = document.createElement('span');
+                    type.className = 'bg-blue-100 text-blue-800 px-2 py-1 rounded text-sm';
+                    type.textContent = s.type;
+                    const dur = document.createElement('span');
+                    dur.className = 'bg-green-100 text-green-800 px-2 py-1 rounded text-sm';
+                    dur.textContent = s.duration;
+                    const player = document.createElement('span');
+                    player.className = 'bg-purple-100 text-purple-800 px-2 py-1 rounded text-sm';
+                    player.textContent = s.notes || 'N/A';
+                    const date = document.createElement('span');
+                    date.className = 'ml-auto text-sm text-gray-500';
+                    date.textContent = s.date;
+                    li.append(type, dur, player, date);
+                    weeklyList.appendChild(li);
+                });
+            }
+        }
+        renderDashboard();
+    }
 });

--- a/index.html
+++ b/index.html
@@ -28,8 +28,30 @@
     <a href="planning.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Planning</a>
     <a href="progression.html" class="block py-2 px-4 rounded hover:bg-blue-100 transition-colors">Progression</a>
   </nav>
-  <main class="flex-1 ml-48 p-8">
-    <h1 class="text-3xl font-semibold mb-8">Tennis Tracker</h1>
+  <main class="flex-1 ml-48 p-8 space-y-8">
+    <h1 class="text-3xl font-semibold">Tennis Tracker</h1>
+    <section id="dashboard" class="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div class="bg-white p-4 rounded-lg shadow">
+        <div id="metric-sessions" class="text-2xl font-semibold">0</div>
+        <div class="text-gray-600">Sessions jouées</div>
+      </div>
+      <div class="bg-white p-4 rounded-lg shadow">
+        <div id="metric-time" class="text-2xl font-semibold">0</div>
+        <div class="text-gray-600">Temps total</div>
+      </div>
+      <div class="bg-white p-4 rounded-lg shadow">
+        <div id="metric-tasks" class="text-2xl font-semibold">0</div>
+        <div class="text-gray-600">Tâches en cours</div>
+      </div>
+      <div class="bg-white p-4 rounded-lg shadow">
+        <div id="metric-players" class="text-2xl font-semibold">0</div>
+        <div class="text-gray-600">Joueurs rencontrés</div>
+      </div>
+    </section>
+    <section>
+      <h2 class="text-xl font-semibold mb-2">Sessions de la semaine</h2>
+      <ul id="weekly-sessions" class="space-y-2"></ul>
+    </section>
     <div class="grid md:grid-cols-2 gap-6">
       <a href="tasks.html" class="block bg-white p-6 rounded-lg shadow hover:bg-blue-50 transition-colors">
         <h2 class="text-xl font-semibold mb-2">Tâches</h2>


### PR DESCRIPTION
## Summary
- enhance home page layout
- show a dashboard with sessions, time played, tasks in progress and players count
- list recent sessions in pastel labels
- compute metrics in `app.js`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842fb60388c8333b10b0950695ea734